### PR TITLE
relax bytestring and containers deps for ghc 7.5

### DIFF
--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -34,7 +34,7 @@ Library
     base          >= 4    && < 5,
     blaze-builder >= 0.2  && < 0.4,
     text          >= 0.10 && < 0.12,
-    bytestring    >= 0.9  && < 0.10
+    bytestring    >= 0.9  && < 0.11
 
 Test-suite blaze-markup-tests
   Type:           exitcode-stdio-1.0
@@ -49,7 +49,7 @@ Test-suite blaze-markup-tests
   Build-depends:
     HUnit                      >= 1.2 && < 1.3,
     QuickCheck                 >= 2.4 && < 2.5,
-    containers                 >= 0.3 && < 0.5,
+    containers                 >= 0.3 && < 0.6,
     test-framework             >= 0.4 && < 0.7,
     test-framework-hunit       >= 0.2 && < 0.3,
     test-framework-quickcheck2 >= 0.2 && < 0.3,
@@ -57,7 +57,7 @@ Test-suite blaze-markup-tests
     base          >= 4    && < 5,
     blaze-builder >= 0.2  && < 0.4,
     text          >= 0.10 && < 0.12,
-    bytestring    >= 0.9  && < 0.10
+    bytestring    >= 0.9  && < 0.11
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
fixes issue #2 relax bytestring version constraint
tested with 7.5.20120517 (and 7.4.1)
