### PR TITLE
Bump text upper version bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ local
 *.hi
 *.swp
 
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+
 TestSuite.tix
 .hpc
 hpc

--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -36,7 +36,7 @@ Library
   Build-depends:
     base          >= 4    && < 5,
     blaze-builder >= 0.2  && < 0.4,
-    text          >= 0.10 && < 1.2,
+    text          >= 0.10 && < 1.3,
     bytestring    >= 0.9  && < 0.11
 
 Test-suite blaze-markup-tests
@@ -59,7 +59,7 @@ Test-suite blaze-markup-tests
     -- Copied from regular dependencies...
     base          >= 4    && < 5,
     blaze-builder >= 0.2  && < 0.4,
-    text          >= 0.10 && < 1.2,
+    text          >= 0.10 && < 1.3,
     bytestring    >= 0.9  && < 0.11
 
 Source-repository head


### PR DESCRIPTION
Allow `blaze-markup` to use `text-1.2.0.0`.
