### PR TITLE
Bump blaze-builder upper version bounds

### DIFF
--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -35,7 +35,7 @@ Library
 
   Build-depends:
     base          >= 4    && < 5,
-    blaze-builder >= 0.2  && < 0.4,
+    blaze-builder >= 0.2  && < 0.5,
     text          >= 0.10 && < 1.3,
     bytestring    >= 0.9  && < 0.11
 


### PR DESCRIPTION
Allow building with the latest version of `blaze-builder` (which, as far as I can tell, simply removes some `Internal` modules that aren't used in `blaze-markup`).