### PR TITLE
Allow monadic binding of MarkupM in most cases

### DIFF
--- a/src/Text/Blaze/Renderer/Pretty.hs
+++ b/src/Text/Blaze/Renderer/Pretty.hs
@@ -1,5 +1,6 @@
 -- | A renderer that produces pretty HTML, mostly meant for debugging purposes.
 --
+{-# LANGUAGE GADTs #-}
 module Text.Blaze.Renderer.Pretty
     ( renderMarkup
     , renderHtml
@@ -37,7 +38,7 @@ renderString = go 0 id
     go i _ (Comment comment) = ind i .
         ("<!-- " ++) . fromChoiceString comment . (" -->\n" ++)
     go i attrs (Append h1 h2) = go i attrs h1 . go i attrs h2
-    go _ _ Empty = id
+    go _ _ (Empty _) = id
     {-# NOINLINE go #-}
 
     -- Increase the indentation

--- a/src/Text/Blaze/Renderer/String.hs
+++ b/src/Text/Blaze/Renderer/String.hs
@@ -1,7 +1,7 @@
 -- | A renderer that produces a native Haskell 'String', mostly meant for
 -- debugging purposes.
 --
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, GADTs #-}
 module Text.Blaze.Renderer.String
     ( fromChoiceString
     , renderMarkup
@@ -80,7 +80,7 @@ renderString = go id
     go _ (Comment comment) =
         ("<!-- " ++) . fromChoiceString comment . (" -->" ++)
     go attrs (Append h1 h2) = go attrs h1 . go attrs h2
-    go _ Empty = id
+    go _ (Empty _) = id
     {-# NOINLINE go #-}
 {-# INLINE renderString #-}
 

--- a/src/Text/Blaze/Renderer/Text.hs
+++ b/src/Text/Blaze/Renderer/Text.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, GADTs #-}
 -- | A renderer that produces a lazy 'L.Text' value, using the Text Builder.
 --
 module Text.Blaze.Renderer.Text
@@ -126,7 +126,7 @@ renderMarkupBuilderWith d = go mempty
             `mappend` fromChoiceString d comment
             `mappend` " -->"
     go attrs (Append h1 h2) = go attrs h1 `mappend` go attrs h2
-    go _ Empty              = mempty
+    go _ (Empty _)          = mempty
     {-# NOINLINE go #-}
 {-# INLINE renderMarkupBuilderWith #-}
 

--- a/src/Text/Blaze/Renderer/Utf8.hs
+++ b/src/Text/Blaze/Renderer/Utf8.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, GADTs #-}
 module Text.Blaze.Renderer.Utf8
     ( renderMarkupBuilder
     , renderMarkup
@@ -92,7 +92,7 @@ renderMarkupBuilder = go mempty
             `mappend` fromChoiceString comment
             `mappend` B.fromByteString " -->"
     go attrs (Append h1 h2) = go attrs h1 `mappend` go attrs h2
-    go _ Empty              = mempty
+    go _ (Empty _)          = mempty
     {-# NOINLINE go #-}
 {-# INLINE renderMarkupBuilder #-}
 


### PR DESCRIPTION
This makes the `Monad MarkupM` instance work in most cases by giving `Empty` a value.  I've run the benchmarks a few times and it does not seem to have any measurable impact on performance.

Seeing the monad instance originally led me to figure I could safely wrap it in a monad transformer, which seemed to go fine until I got a runtime error.  I understand the motivation for providing the current instance was just for convenient `do` syntax, but it is a bit misleading.  The resulting fix is not the best monad instance -- it's kind of inefficient in some deeply nested cases -- but this is better than being completely broken.  As long as this has no impact on the normal performance of the library, there doesn't seem any reason not to have it.

Unfortunately I coludn't fix this for string literals (`IsString`), but in practice that's rarely an issue.  The only exposed type that changes is `contents` but I can't think how this would cause any problems.

If you'd rather not do this, it would at least be nice to document that the existing Monad instance is broken.
