### PR TITLE
Split 'go' into with/without attrs code paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ local
 cabal.sandbox.config
 cabal.config
 
+report.html
 TestSuite.tix
 .hpc
 hpc

--- a/src/Text/Blaze/Renderer/String.hs
+++ b/src/Text/Blaze/Renderer/String.hs
@@ -59,29 +59,52 @@ fromChoiceString EmptyChoiceString = id
 renderString :: Markup    -- ^ Markup to render
              -> String  -- ^ String to append
              -> String  -- ^ Resulting String
-renderString = go id
+renderString = go
   where
-    go :: (String -> String) -> MarkupM b -> String -> String
-    go attrs (Parent _ open close content) =
-        getString open . attrs . ('>' :) . go id content . getString close
-    go attrs (CustomParent tag content) =
-        ('<' :) . fromChoiceString tag . attrs . ('>' :) .  go id content .
+    go :: MarkupM b -> String -> String
+    go (Parent _ open close content) =
+        getString open . ('>' :) . go content . getString close
+    go (CustomParent tag content) =
+        ('<' :) . fromChoiceString tag . ('>' :) .  go content .
         ("</" ++) . fromChoiceString tag . ('>' :)
-    go attrs (Leaf _ begin end) = getString begin . attrs . getString end
-    go attrs (CustomLeaf tag close) =
+    go (Leaf _ begin end) = getString begin . getString end
+    go (CustomLeaf tag close) =
+        ('<' :) . fromChoiceString tag .
+        (if close then (" />" ++) else ('>' :))
+    go (AddAttribute _ key value h) = flip go_attrs h $
+        getString key . fromChoiceString value . ('"' :)
+    go (AddCustomAttribute key value h) = flip go_attrs h $
+        (' ' :) . fromChoiceString key . ("=\"" ++) . fromChoiceString value .
+        ('"' :)
+    go (Content content) = fromChoiceString content
+    go (Comment comment) =
+        ("<!-- " ++) . fromChoiceString comment . (" -->" ++)
+    go (Append h1 h2) = go h1 . go h2
+    go Empty = id
+    {-# NOINLINE go #-}
+
+    go_attrs :: (String -> String) -> MarkupM b -> String -> String
+    go_attrs attrs (Parent _ open close content) =
+        getString open . attrs . ('>' :) . go content . getString close
+    go_attrs attrs (CustomParent tag content) =
+        ('<' :) . fromChoiceString tag . attrs . ('>' :) .  go content .
+        ("</" ++) . fromChoiceString tag . ('>' :)
+    go_attrs attrs (Leaf _ begin end) = getString begin . attrs . getString end
+    go_attrs attrs (CustomLeaf tag close) =
         ('<' :) . fromChoiceString tag . attrs .
         (if close then (" />" ++) else ('>' :))
-    go attrs (AddAttribute _ key value h) = flip go h $
+    go_attrs attrs (AddAttribute _ key value h) = flip go_attrs h $
         getString key . fromChoiceString value . ('"' :) . attrs
-    go attrs (AddCustomAttribute key value h) = flip go h $
+    go_attrs attrs (AddCustomAttribute key value h) = flip go_attrs h $
         (' ' :) . fromChoiceString key . ("=\"" ++) . fromChoiceString value .
         ('"' :) .  attrs
-    go _ (Content content) = fromChoiceString content
-    go _ (Comment comment) =
+    go_attrs _ (Content content) = fromChoiceString content
+    go_attrs _ (Comment comment) =
         ("<!-- " ++) . fromChoiceString comment . (" -->" ++)
-    go attrs (Append h1 h2) = go attrs h1 . go attrs h2
-    go _ Empty = id
-    {-# NOINLINE go #-}
+    go_attrs attrs (Append h1 h2) = go_attrs attrs h1 . go_attrs attrs h2
+    go_attrs _ Empty = id
+    {-# NOINLINE go_attrs #-}
+
 {-# INLINE renderString #-}
 
 -- | Render markup to a lazy 'String'.

--- a/src/Text/Blaze/Renderer/Utf8.hs
+++ b/src/Text/Blaze/Renderer/Utf8.hs
@@ -47,53 +47,93 @@ fromChoiceString EmptyChoiceString = mempty
 --
 renderMarkupBuilder, renderHtmlBuilder :: Markup     -- ^ Markup to render
                   -> Builder  -- ^ Resulting builder
-renderMarkupBuilder = go mempty
+renderMarkupBuilder = go
   where
-    go :: Builder -> MarkupM b -> Builder
-    go attrs (Parent _ open close content) =
+    go :: MarkupM b -> Builder
+    go (Parent _ open close content) =
+        B.copyByteString (getUtf8ByteString open)
+            `mappend` B.fromChar '>'
+            `mappend` go content
+            `mappend` B.copyByteString (getUtf8ByteString close)
+    go (CustomParent tag content) =
+        B.fromChar '<'
+            `mappend` fromChoiceString tag
+            `mappend` B.fromChar '>'
+            `mappend` go content
+            `mappend` B.fromByteString "</"
+            `mappend` fromChoiceString tag
+            `mappend` B.fromChar '>'
+    go (Leaf _ begin end) =
+        B.copyByteString (getUtf8ByteString begin)
+            `mappend` B.copyByteString (getUtf8ByteString end)
+    go (CustomLeaf tag close) =
+        B.fromChar '<'
+            `mappend` fromChoiceString tag
+            `mappend` (if close then B.fromByteString " />" else B.fromChar '>')
+    go (AddAttribute _ key value h) =
+        go_attrs (B.copyByteString (getUtf8ByteString key)
+                 `mappend` fromChoiceString value
+                 `mappend` B.fromChar '"') h
+    go (AddCustomAttribute key value h) =
+        go_attrs (B.fromChar ' '
+                 `mappend` fromChoiceString key
+                 `mappend` B.fromByteString "=\""
+                 `mappend` fromChoiceString value
+                 `mappend` B.fromChar '"') h
+    go (Content content)  = fromChoiceString content
+    go (Comment comment)  =
+        B.fromByteString "<!-- "
+            `mappend` fromChoiceString comment
+            `mappend` B.fromByteString " -->"
+    go (Append h1 h2) = go h1 `mappend` go h2
+    go Empty              = mempty
+    {-# NOINLINE go #-}
+
+    go_attrs :: Builder -> MarkupM b -> Builder
+    go_attrs attrs (Parent _ open close content) =
         B.copyByteString (getUtf8ByteString open)
             `mappend` attrs
             `mappend` B.fromChar '>'
-            `mappend` go mempty content
+            `mappend` go content
             `mappend` B.copyByteString (getUtf8ByteString close)
-    go attrs (CustomParent tag content) =
+    go_attrs attrs (CustomParent tag content) =
         B.fromChar '<'
             `mappend` fromChoiceString tag
             `mappend` attrs
             `mappend` B.fromChar '>'
-            `mappend` go mempty content
+            `mappend` go content
             `mappend` B.fromByteString "</"
             `mappend` fromChoiceString tag
             `mappend` B.fromChar '>'
-    go attrs (Leaf _ begin end) =
+    go_attrs attrs (Leaf _ begin end) =
         B.copyByteString (getUtf8ByteString begin)
             `mappend` attrs
             `mappend` B.copyByteString (getUtf8ByteString end)
-    go attrs (CustomLeaf tag close) =
+    go_attrs attrs (CustomLeaf tag close) =
         B.fromChar '<'
             `mappend` fromChoiceString tag
             `mappend` attrs
             `mappend` (if close then B.fromByteString " />" else B.fromChar '>')
-    go attrs (AddAttribute _ key value h) =
-        go (B.copyByteString (getUtf8ByteString key)
+    go_attrs attrs (AddAttribute _ key value h) =
+        go_attrs (B.copyByteString (getUtf8ByteString key)
             `mappend` fromChoiceString value
             `mappend` B.fromChar '"'
             `mappend` attrs) h
-    go attrs (AddCustomAttribute key value h) =
-        go (B.fromChar ' '
+    go_attrs attrs (AddCustomAttribute key value h) =
+        go_attrs (B.fromChar ' '
             `mappend` fromChoiceString key
             `mappend` B.fromByteString "=\""
             `mappend` fromChoiceString value
             `mappend` B.fromChar '"'
             `mappend` attrs) h
-    go _ (Content content)  = fromChoiceString content
-    go _ (Comment comment)  =
+    go_attrs _ (Content content)  = fromChoiceString content
+    go_attrs _ (Comment comment)  =
         B.fromByteString "<!-- "
             `mappend` fromChoiceString comment
             `mappend` B.fromByteString " -->"
-    go attrs (Append h1 h2) = go attrs h1 `mappend` go attrs h2
-    go _ Empty              = mempty
-    {-# NOINLINE go #-}
+    go_attrs attrs (Append h1 h2) = go_attrs attrs h1 `mappend` go_attrs attrs h2
+    go_attrs _ Empty              = mempty
+    {-# NOINLINE go_attrs #-}
 {-# INLINE renderMarkupBuilder #-}
 
 renderHtmlBuilder = renderMarkupBuilder


### PR DESCRIPTION

This is the first of two pull requests that do some internal rewiring. This
first change improves BigTable performance considerably with no negative effect
on other benchmarks.

**bigTable/Utf8 runs 25% faster.**

If there is any value to be found in the BigTable benchmark, this is not a
trivial improvement. It will make the [Blaze benchmarks][benchmark] page even
more impressive.

[benchmark]: http://jaspervdj.be/blaze/benchmarks.html

The change is simple: begin `renderXXX` with the assumption that an element has
no attributes, then procede with the original algorithm when encountering an
`Add[Custom]Attribute`.

As mentioned above, this suggestion precedes another pull request that will
yield _almost_ (within 3%) identical performance while promoting CSS styles and
classes to the same syntactic sweetness as attributes. I initially split the
`go` function because I couldn't find any other way to make my CSS additions an
'optional' package. I thought I'd just make them an optional part of the core
algorithm. It turns out that the same technique (thinking of attributes as an
'optional' feature) has a pleasant effect on the original algorithm.

I have one lingering question about the benchmark results. Why does this
modification have such a drastic effect on the Utf8 benchmarks (including
wideTable and basic) and not the others? I'll guess that the reason is hiding
somewhere in GHC's optimizations, but it would be nice to know. I'd expect to
see a similar decrease in execution time across the other modules (in _ms_, not
%).

One idea is that in `Blaze.ByteString.Builder`, the `mempty = Builder id` is
somehow not being opitmized and that the _master_ branch's `*/Utf8` speeds could
have been better all along. Hence, replacing `renderMarkup = go id` and
`renderMarkupBuilder[With] = go mempty` with `... = go` resulted in better
improvement in the `Text.Blaze.Renderer.Utf8` module than in the others.
