### PR TITLE
blaze-markup.cabal: allow newer tasty-0.12 and tasty-hunit-0.10

### DIFF
--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -59,8 +59,8 @@ Test-suite blaze-markup-tests
     HUnit            >= 1.2  && < 1.7,
     QuickCheck       >= 2.4  && < 2.11,
     containers       >= 0.3  && < 0.6,
-    tasty            >= 0.11 && < 0.12,
-    tasty-hunit      >= 0.9  && < 0.10,
+    tasty            >= 0.11 && < 0.13,
+    tasty-hunit      >= 0.9  && < 0.11,
     tasty-quickcheck >= 0.8  && < 0.10,
     -- Copied from regular dependencies...
     base          >= 4    && < 5,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>