### PR TITLE
Relax constraints on base, containers, and tasty for ghc 8.6

### DIFF
--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -36,7 +36,7 @@ Library
     Text.Blaze.Renderer.Utf8
 
   Build-depends:
-    base          >= 4    && < 4.12,
+    base          >= 4    && < 4.13,
     blaze-builder >= 0.3  && < 0.5,
     text          >= 0.10 && < 1.3,
     bytestring    >= 0.9  && < 0.11
@@ -60,12 +60,12 @@ Test-suite blaze-markup-tests
   Build-depends:
     HUnit            >= 1.2  && < 1.7,
     QuickCheck       >= 2.7  && < 2.12,
-    containers       >= 0.3  && < 0.6,
-    tasty            >= 1.0  && < 1.1,
+    containers       >= 0.3  && < 0.7,
+    tasty            >= 1.0  && < 1.2,
     tasty-hunit      >= 0.10 && < 0.11,
     tasty-quickcheck >= 0.10 && < 0.11,
     -- Copied from regular dependencies...
-    base          >= 4    && < 4.12,
+    base          >= 4    && < 4.13,
     blaze-builder >= 0.3  && < 0.5,
     text          >= 0.10 && < 1.3,
     bytestring    >= 0.9  && < 0.11


### PR DESCRIPTION
Tests for this commit passed for me on my local machine when I ran them like so:

```bash
$ edit stack.yam # add the following stack.yaml
$ stack test
```

```yaml
# stack.yaml
resolver: nightly-2018-09-23
compiler: ghc-8.6.1
extra-deps:
- stm-2.5.0.0
- containers-0.6.0.1
```