### PR TITLE
Permit base-4.13, tasty-1.2, QuickCheck-2.13

### DIFF
--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -36,7 +36,7 @@ Library
     Text.Blaze.Renderer.Utf8
 
   Build-depends:
-    base          >= 4    && < 4.13,
+    base          >= 4    && < 4.14,
     blaze-builder >= 0.3  && < 0.5,
     text          >= 0.10 && < 1.3,
     bytestring    >= 0.9  && < 0.11
@@ -59,13 +59,13 @@ Test-suite blaze-markup-tests
 
   Build-depends:
     HUnit            >= 1.2  && < 1.7,
-    QuickCheck       >= 2.7  && < 2.12,
+    QuickCheck       >= 2.7  && < 2.14,
     containers       >= 0.3  && < 0.7,
-    tasty            >= 1.0  && < 1.2,
+    tasty            >= 1.0  && < 1.3,
     tasty-hunit      >= 0.10 && < 0.11,
     tasty-quickcheck >= 0.10 && < 0.11,
     -- Copied from regular dependencies...
-    base          >= 4    && < 4.13,
+    base          >= 4    && < 4.14,
     blaze-builder >= 0.3  && < 0.5,
     text          >= 0.10 && < 1.3,
     bytestring    >= 0.9  && < 0.11


### PR DESCRIPTION
This is necessary to allow `blaze-markup` to build with GHC 8.8.1.

Fixes #44. Supersedes #43.