### PR TITLE
Allow bytestring-0.11

### DIFF
--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -41,7 +41,7 @@ Library
     base          >= 4    && < 4.15,
     blaze-builder >= 0.3  && < 0.5,
     text          >= 0.10 && < 1.3,
-    bytestring    >= 0.9  && < 0.11
+    bytestring    >= 0.9  && < 0.12
 
 Test-suite blaze-markup-tests
   Type:             exitcode-stdio-1.0
@@ -71,7 +71,7 @@ Test-suite blaze-markup-tests
     base          >= 4    && < 4.15,
     blaze-builder >= 0.3  && < 0.5,
     text          >= 0.10 && < 1.3,
-    bytestring    >= 0.9  && < 0.11
+    bytestring    >= 0.9  && < 0.12
 
 Source-repository head
   Type:     git


### PR DESCRIPTION
Tested using
```cabal
packages: .
tests: true

constraints:
  bytestring >= 0.11

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

source-repository-package
  type: git
  location: https://github.com/Bodigrim/blaze-builder

allow-newer:
  regex-base:bytestring,
  regex-posix:bytestring
```