### PR TITLE
Allow base 4.17 and text 2.0

### DIFF
--- a/blaze-markup.cabal
+++ b/blaze-markup.cabal
@@ -20,7 +20,7 @@ Cabal-version: >= 1.10
 Tested-with:   GHC == 7.8.4, GHC == 7.10.3,
                GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4,
                GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4,
-               GHC == 9.0.1
+               GHC == 9.0.1, GHC == 9.2.1
 
 Extra-source-files:
   CHANGELOG
@@ -39,9 +39,9 @@ Library
     Text.Blaze.Renderer.Utf8
 
   Build-depends:
-    base          >= 4    && < 4.16,
+    base          >= 4    && < 4.17,
     blaze-builder >= 0.3  && < 0.5,
-    text          >= 0.10 && < 1.3,
+    text          >= 0.10 && < 2.1,
     bytestring    >= 0.9  && < 0.12
 
 Test-suite blaze-markup-tests
@@ -69,9 +69,9 @@ Test-suite blaze-markup-tests
     tasty-hunit      >= 0.10 && < 0.11,
     tasty-quickcheck >= 0.10 && < 0.11,
     -- Copied from regular dependencies...
-    base          >= 4    && < 4.16,
+    base          >= 4    && < 4.17,
     blaze-builder >= 0.3  && < 0.5,
-    text          >= 0.10 && < 1.3,
+    text          >= 0.10 && < 2.1,
     bytestring    >= 0.9  && < 0.12
 
 Source-repository head


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' -w ghc-9.2.1
