### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/src/Text/Blaze/Internal.hs
+++ b/src/Text/Blaze/Internal.hs
@@ -220,9 +220,11 @@ instance Applicative MarkupM where
     -- {-# INLINE (<*) #-}
 
 instance Monad MarkupM where
+#if !MIN_VERSION_base(4,8,0)
     return x = Empty x
     {-# INLINE return #-}
-    (>>) = Append
+#endif
+    (>>) = (*>)
     {-# INLINE (>>) #-}
     h1 >>= f = Append h1 (f (markupValue h1))
     {-# INLINE (>>=) #-}


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return